### PR TITLE
Pass block number to block handler

### DIFF
--- a/statereceiver.js
+++ b/statereceiver.js
@@ -185,10 +185,10 @@ class StateReceiver {
         if (block){
             this.block_handlers.forEach((handler) => {
                 if (this.mode === 0){
-                    handler.processBlock(block)
+                    handler.processBlock(block_num, block)
                 }
                 else {
-                    handler.queueBlock(block)
+                    handler.queueBlock(block_num, block)
                 }
             })
         }


### PR DESCRIPTION
Perhaps I'm missing something, but it seems the block handler doesn't get access to the block number. This change passes it in like the other handlers.